### PR TITLE
search for public keys in .ssh/pub directory?

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -748,11 +748,17 @@ ssh_l() {
 ssh_f() {
     sf_filename="$1"
     if $openssh || $sunssh; then
-        if [ ! -f "$sf_filename.pub" ]; then
+        if [ -f "$sf_filename.pub" ]; then
+            sf_pubkey="$sf_filename.pub"
+        else if [ -f "pub/$sf_filename.pub" ]; then
+            sf_pubkey="pub/$sf_filename.pub"
+        else if [ -f "pub/$sf_filename" ]; then
+            sf_pubkey="pub/$sf_filename"
+        else
             warn "$sf_filename.pub missing; can't tell if $sf_filename is loaded"
             return 1
         fi
-        sf_fing=`ssh-keygen -l -f "$sf_filename.pub"` || return 1
+        sf_fing=`ssh-keygen -l -f "$sf_pubkey"` || return 1
         echo "$sf_fing" | extract_fingerprints
     else
         # can't get fingerprint for ssh2 so use filename *shrug*


### PR DESCRIPTION
I like to keep my public keys and private keys in separate directories, to reduce the chance that I accidentally use one when I meant to use the other. I have a "pub" directory in my .ssh directory where I move all my public keys, and I leave my private keys in the .ssh directory where most applications expect to find them. Keychain looks for public keys as well, though.

I've added a patch for Keychain so that if it doesn't find the public key in .ssh, it also searches .ssh/pub. Is that acceptable?
