### PR TITLE
Write ~/.gpg-agent-info when launching gpg-agent...

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -599,7 +599,7 @@ startagent() {
                 unset start_gpg_timeout
             fi
             # the 1.9.x series of gpg spews debug on stderr
-            start_out=`gpg-agent --daemon $start_gpg_timeout 2>/dev/null`
+            start_out=`gpg-agent --daemon --write-env-file $start_gpg_timeout 2>/dev/null`
         else
             error "I don't know how to start $start_prog-agent (2)"
             return 1


### PR DESCRIPTION
... for better compatibility with other things using it, e.g. KDE 4:
see: https://bugzilla.redhat.com/show_bug.cgi?id=486025

Patch from: Ville Skyttä
