### PR TITLE
Adding .ssh/config

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -1105,8 +1105,7 @@ while [ -n "$1" ]; do
         --quiet|-q)
             quietopt=true
             ;;
-        --confhost)
-            echo "$2"
+        --confhost|-c)
             sshconfig=true
             confhost="$2"
             ;;


### PR DESCRIPTION
Added the --confhost option that can scan the ~/.ssh/config configuration file and locate the right path to the private key. If the key is not already in cache, the user is asked for the password of the key. After that the key is added to the keystore. This option was implemented because I needed a way to automatically add a key to keystore based on the name in the .ssh/config file. Now when I don't have the key in my cache and would like to connect to my server  I can simply use the following command:
# ssh server

Where the ssh is this function:

function ssh() {
  keychain -c "$1"
  /usr/bin/ssh "$1"
}

Keychain will then locate appropriate path to the private key from .ssh/config (based on Host 'server') and ask the user for a password, adding the private key to the keystore.

Then the keychain will quit and let ssh connect without authentication.

The benefit of this is if we're connecting to a server via SSH command, typing in the password and do something on the server. Then we logout and we remember that we forgot to do something and when sshing to the server, we have to type in the same password. Alternatively we could call ssh-add every time needed. With the solution we can avoid thinking which ssh key belongs to which host, but the data is available in .ssh/config so why not use it.
