### PR TITLE
Fix --eval output when using FISH

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -650,7 +650,7 @@ SSH2_AGENT_PID=$inherit_ssh2_agent_pid; export SSH2_AGENT_PID;"
         *)
             echo "$start_out" >"$start_pidf"
             echo "$start_out" | sed 's/;.*/;/' | sed 's/=/ /' | sed 's/^/setenv /' >"$start_cshpidf"
-            echo "$start_out" | sed 's/;.*/;/' | sed 's/^\(.*\)=\(.*\);/set -e \1; and set -x -U \1 \2/' >"$start_fishpidf"
+            echo "$start_out" | sed 's/;.*/;/' | sed 's/^\(.*\)=\(.*\);/set -e \1; set -x -U \1 \2;/' >"$start_fishpidf"
             ;;
     esac
 


### PR DESCRIPTION
This commit fixes two problems with the output of `keychain --eval` when using FISH.

Firstly, you could not run `eval (keychain --eval)` because of missing semi-colons at the end of each line, which necessitated workarounds like `for e in (keychain --eval); eval "$e"; end`. You can see why with `echo (keychain --eval)`: all lines are joined, so directly evaluating it would execute commands like `set -x -U SSH_AUTH_SOCK /tmp/ssh-QdKWiXUO1468/agent.1468 set -e SSH_AGENT_PID`. Needless to say, programs were not able to connect to ssh-agent.  This is fixed by adding an appropriate `;` in the sed command.

Secondly, the use of `and` meant that, should an environment variable not exist already, evaluating the `--eval` output would not set it. This is fixed by removing the `and` from the sed command.

Note that I am using fish-2.0.0. I haven't tested with older versions, but I can't imagine why any problems would arise from these changes.
