### PR TITLE
Fix path to socket for gpg_agent_info

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -377,7 +377,7 @@ inheritagents() {
             # GnuPG v.2.1+ removes $GPG_AGENT_INFO
             elif [ -S "${GNUPGHOME:=$HOME/.gnupg}/S.gpg-agent" ]; then
                 inherit_gpg_agent_pid=$(ps -u "$me" -o 'pid,comm' | grep gpg-agent | tr -dc '[:digit:]')
-                inherit_gpg_agent_info="$GNUPGHOME/S.gpgagent:${inherit_gpg_agent_pid}:1"
+                inherit_gpg_agent_info="${GNUPGHOME}/S.gpg-agent:${inherit_gpg_agent_pid}:1"
             fi
         fi
     fi


### PR DESCRIPTION
Fixes misnamed socket as pointed out by @hellekin in #23