### PR TITLE
Re-introduce POSIX compatibility

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -56,8 +56,6 @@ unset ssh_confirm
 unset GREP_OPTIONS
 realpath_bin="`command -v realpath`"
 
-shopt -s extglob
-
 BLUE="[34;01m"
 CYAN="[36;01m"
 CYANN="[36m"
@@ -683,7 +681,7 @@ extract_fingerprints() {
 				#	1024 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 /home/barney/.ssh/id_dsa (DSA)
 				echo "$ef_line" | cut -f2 -d' '
 				;;
-			*\ @(SHA256|MD5):[0-9a-zA-Z\+\/=]*)
+			*\ SHA256:[0-9a-zA-Z\+\/=]*|*\ MD5:[0-9a-zA-Z\+\/=]*)
 				# The new OpenSSH 6.8+ format,
 				#   1024 SHA256:mVPwvezndPv/ARoIadVY98vAC0g+P/5633yTC4d/wXE /home/barney/.ssh/id_dsa (DSA)
 				echo "$ef_line" | cut -f2 -d' '


### PR DESCRIPTION
By making the openssh 6.8 format match slightly more verbose, one can make it POSIX compatible again and remove the bashism "shopt". This way, the script works (again) if /bin/sh is a symlink to dash.