### PR TITLE
Fix issue where make fails on Windows/cygwin due to line endings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ GENKEYCHAINPL = open P, "keychain.txt" or die "cant open keychain.txt"; \
 		open B, "keychain.sh" or die "cant open keychain.sh"; \
 			$$/ = undef; \
 			$$_ = <B>; \
-			s/INSERT_POD_OUTPUT_HERE\n/$$pod/ || die; \
+			s/INSERT_POD_OUTPUT_HERE[\r\n]/$$pod/ || die; \
 			s/\#\#VERSION\#\#/$V/g || die; \
 		print
 


### PR DESCRIPTION
Running `make` on Windows/cygwin dies with the following:

```
$ make
pod2man --name=keychain --release=2.8.0 \
        --center='http://www.funtoo.org' \
        keychain.pod keychain.1
sed -i.orig -e "s/^'br/.br/" keychain.1
pod2text keychain.pod keychain.txt
perl -e 'open P, "keychain.txt" or die "cant open keychain.txt"; while (<P>) { $printing = 0 if /^\w/; $printing = 1 if /^(SYNOPSIS|OPTIONS)/; $printing || next; s/\$/\\\$/g; s/\`/\\\`/g; s/\\$/\\\\/g; s/\*(\w+)\*/\${CYAN}$1\${OFF}/g; s/(^|\s)(-+[-\w]+)/$1\${GREEN}$2\${OFF}/g; $pod .= $_; }; open B, "keychain.sh" or die "cant open keychain.sh"; $/ = undef; $_ = <B>; s/INSERT_POD_OUTPUT_HERE\n/$pod/ || die; s/##VERSION##/2.8.0/g || die; print' >keychain || rm -f keychain
Died at -e line 1, <B> chunk 1.
chmod +x keychain
chmod: cannot access ‘keychain’: No such file or directory
Makefile:48: recipe for target 'keychain' failed
make: *** [keychain] Error 1
```