### PR TITLE
Make sure only sh string equality is used

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -972,13 +972,16 @@ confpath() {
 	h=""
 	while IFS= read -r line; do
 		# get the Host directives
-		if [[ $line == *"Host "* ]]; then
-			h=$(echo $line | awk '{print $2}')
-		fi
-		if [[ $line == *IdentityFile* ]] && [[ $h == "$1" ]]; then
-			echo $line | awk '{print $2}'
-			break
-		fi
+                case $line in
+                    *"Host "*) h=$(echo $line | awk '{print $2}') ;;
+                esac
+                case $line in
+                    *IdentityFile*)
+                        if [[ $h = "$1" ]]; then
+                            echo $line | awk '{print $2}'
+                            break
+                        fi
+                esac
 	done < ~/.ssh/config
 }
 
@@ -1372,7 +1375,7 @@ if wantagent ssh; then
 	sshavail=`ssh_l`				# update sshavail now that we're locked
 	if [ "$myaction" = "list" ]; then
 		for key in $sshavail end; do
-			[ "$key" == "end" ] && continue
+			[ "$key" = "end" ] && continue
 			echo "$key"
 		done
 	else


### PR DESCRIPTION
As #!/bin/sh is at the top of the file, only standard sh features are available