### PR TITLE
/bin/sh might not be bash!

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 1999-2005 Gentoo Foundation
 # Copyright 2007 Aron Griffis <agriffis@n01se.net>


### PR DESCRIPTION
keychain seems to work perfectly well on Solaris, except /bin/sh is not going to be bash, but a really ancient original Bourne-style shell.

We should use /bin/bash to be sure we get bash.
