### PR TITLE
Fix adding GPG keys

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -911,13 +911,10 @@ parse_mykeys() {
 
 		# Check for gpg
 		if wantagent gpg; then
-			if [ -z "$pm_gpgsecrets" ]; then
-				pm_gpgsecrets="$(gpg --list-secret-keys 2>/dev/null | cut -d/ -f2 | cut -d' ' -f1 | xargs)"
-				[ -z "$pm_gpgsecrets" ] && pm_gpgsecrets='/'	# arbitrary
+			gpg --list-secret-keys "$pm_k" >/dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				add_gpgkey "$pm_k" ; continue
 			fi
-			case " $pm_gpgsecrets " in *" $pm_k "*)
-				add_gpgkey "$pm_k" ; continue ;;
-			esac
 		fi
 
 		$ignoreopt || warn "can't find $pm_k; skipping"


### PR DESCRIPTION
GnuPG 2.1.13 changed the default output of `gpg --list-secret-keys`, which
results in keychain being no longer able to add GPG keys.

http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=b047388d57443f584f1c1d6333aac5218b685042

Old default format:

```
/home/user/.gnupg/secring.gpg
-----------------------------
sec   4096R/DEADBEEF 2010-01-01
uid                  John Doe <john.doe@example.com>
ssb   4096R/FEEBDAED 2010-01-01
```

New default format:

```
/home/user/.gnupg/pubring.gpg
-----------------------------
sec   rsa4096 2010-01-01 [SC]
      0123456789ABCDEF0123456789ABCDEFDEADBEEF
uid           [ultimate] John Doe <john.doe@example.com>
ssb   rsa4096 2010-01-01 [E]
```

This patch makes use of calling `gpg --list-secret-keys KEY_ID` and checking
its exit status to determine whether a given secret key exists or not.
