### PR TITLE
don't require public key

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -776,8 +776,9 @@ ssh_f() {
 			fi
 			lsf_filename=$(echo "$sf_filename" | sed 's/\.[^\.]*$//').pub
 			if [ ! -f "$lsf_filename" ]; then
-				warn "Cannot find public key for $1."
-				return 1
+				warn "Cannot find public key for $sf_filename."
+				basename "$sf_filename"
+				return 0
 			fi
 		fi
 		sf_fing=$(ssh-keygen -l -f "$lsf_filename") || return 1


### PR DESCRIPTION
ssh-agent can work without ssh key, why not keychain?

e.g. the following works fine:

$ rm .ssh/id_rsa.pub
$ eval `ssh-agent`
$ ssh-add