### PR TITLE
Portability changes

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 1999-2005 Gentoo Foundation
 # Copyright 2007 Aron Griffis <agriffis@n01se.net>

--- a/keychain.sh
+++ b/keychain.sh
@@ -145,8 +145,8 @@ testssh() {
 # synopsis: getuser
 # Set the global string $me
 getuser() {
-	# whoami gives euid, which might be different from USER or LOGNAME
-	me=$(whoami) || die "Who are you?  whoami doesn't know..."
+	# id -un gives euid, which might be different from USER or LOGNAME
+	me=$(id -un) || die "Who are you?  whoami doesn't know..."
 }
 
 # synopsis: getos


### PR DESCRIPTION
The changes below are meant to make keychain more portable on different os. The following changes where tested on Linux (CentOS), illumos (smartos) and MacOS.