### PR TITLE
Support busybox ps with the PS_FEATURE_WIDE option

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -257,6 +257,7 @@ findpids() {
 	if [ -z "$fp_psout" ]; then
 		fp_psout=$(UNIX95=1 ps -u $me -o pid,comm 2>/dev/null | grep '^ *[0-9]')
 		[ -z "$fp_psout" ] && fp_psout=$(ps x 2>/dev/null)
+		[ -z "$fp_psout" ] && fp_psout=$(ps w 2>/dev/null) # Busybox syntax
 	fi
 
 	# Return the list of pids; ignore case for Cygwin.


### PR DESCRIPTION
Busybox ps built with PS_FEATURE_WIDE option will print the required information when run with the 'w' argument, but will fail otherwise, so use that to support such systems.

It's possible that there are some options (DESKTOP?) that would mean that a rebuilt busybox would work out of the box, but this seems trivial to add.