### PR TITLE
Add ability to load all keyfiles in `ssh_config`

### DIFF
--- a/keychain.pod
+++ b/keychain.pod
@@ -4,7 +4,7 @@ keychain - re-use ssh-agent and/or gpg-agent between logins
 
 =head1 SYNOPSIS
 
-S<keychain [ -hklQqV ] [ --clear --confhost --gpg2 --help --ignore-missing --list>
+S<keychain [ -hklQqV ] [ --clear --confhost --confallhosts --gpg2 --help --ignore-missing --list>
 S<--noask --nocolor --nogui --nolock --quick --quiet --version ]>
 S<[ --agents I<list> ] [ --attempts I<num> ] [ --dir I<dirname> ]>
 S<[ --host I<name> ] [ --lockwait I<seconds> ]>
@@ -79,8 +79,15 @@ ssh keys when you're logged out.
 
 By default, keychain will look for key pairs in the ~/.ssh/ directory.
 The --confhost option will inform keychain to look in ~/.ssh/config
-for IdentityFile settings defined for particular hosts, and use these
-paths to locate keys.
+for IdentityFile settings defined for the mentioned host (in I<keys>), 
+and use these paths to locate keys.
+
+=item B<--confallhosts>
+
+By default, keychain will look for key pairs in the ~/.ssh/ directory.
+The --confallhosts option will inform keychain to look in ~/.ssh/config
+for IdentityFile settings defined for all hosts, and use these
+paths to locate keys to load.
 
 =item B<--confirm>
 


### PR DESCRIPTION
# Problem

When using the `--confhost` option one can only specify a single host to
load a key from. However one also has to specify for which host to load
the keys from. When you want to load several keyfiles that belong to
several hosts into the keychain, this requires many functioncalls, and
is cumbersome.

I think it should be able to load all the hosts specified in the
`ssh_config` with a single command. Normally the config contains
information about all the hosts that you have keyfiles for, so it would
make sence that a person wants to add all these keys to their keychain
for ease of use.

# Solution

With some minor adjustments to the way `pkeypath` is being used in the
script, its now able to load all the hosts from the configuration file
with a single function call. Personally I will use this during boot to
load all my ssh-keys into my agent so that upon entering my password,
all my servers will be accesible.