### PR TITLE
Automatically recognise gpg-agent if available

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -960,7 +960,7 @@ setagents() {
 		done
 		agentsopt="${new_agentsopt}"
 	else
-		for a in ssh; do
+		for a in ssh gpg; do
 			command -v ${a}-agent >/dev/null || continue
 			agentsopt="${agentsopt+$agentsopt }${a}"
 		done


### PR DESCRIPTION
Man page says:

[..]
OPTIONS
        --agents list
          tart the agents listed. By default keychain will build
          the list automatically based on the existence of ssh-agent
          and/or gpg-agent on the system. The list should be
          comma-separated, for example "gpg,ssh"
[..]

Only ssh was supported. Now both.

Signed-off-by: Mikko Koivunalho <mikko.koivunalho@iki.fi>