### PR TITLE
If PATH doesn't allow id to be found, add the basics to it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,14 @@
 # Maintained July 2009 - September 2017 by Daniel Robbins <drobbins@funtoo.org>
 # Maintained September 2017 - present by Ryan Harris <x48rph@gmail.com>
 
+2021-10-05  Henry S. Thompson  <ht@home.hst.name>
+
+	* keychain.sh: 
+
+	If PATH lacks the basics, add them
+
+	Add a few #' to allow (x)emacs fontify to work better
+	
 * keychain 2.8.5 (24 Jan 2018)
 
   Summary Various fixes and support systemd gnupg sockets

--- a/keychain.sh
+++ b/keychain.sh
@@ -15,7 +15,15 @@
 
 version=##VERSION##
 
-PATH="${PATH:-/usr/bin:/bin:/sbin:/usr/sbin:/usr/ucb}"
+if type -t id > /dev/null
+then
+ :
+elif [ "$PATH" ]
+then
+ PATH=$PATH:/usr/bin:/bin:/sbin:/usr/sbin:/usr/ucb
+else
+ PATH=/usr/bin:/bin:/sbin:/usr/sbin:/usr/ucb
+fi
 
 maintainer="x48rph@gmail.com"
 unset mesglog
@@ -130,7 +138,7 @@ helpinfo() {
 	cat >&1 <<EOHELP
 INSERT_POD_OUTPUT_HERE
 EOHELP
-}
+} #'
 
 # synopsis: testssh
 # Figure out which ssh is in use, set the global boolean $openssh and $sunssh
@@ -171,7 +179,7 @@ verifykeydir() {
 }
 
 lockfile() {
-	# This function originates from Parallels Inc.'s OpenVZ vpsreboot script
+	# This function originates from Parallels Inc.'s OpenVZ vpsreboot script #'
 
 	# Description: This function attempts to acquire the lock. If it succeeds,
 	# it returns 0. If it fails, it returns 1. This function retuns immediately


### PR DESCRIPTION
A non-empty PATH may still not include e.g. `/usr/bin`.  This patch fixes that.

The need for this arises when using Cygwin but invoking `keychain ` from a Windows context, in which case the PATH is not empty but lacks Cygwin paths.