### PR TITLE
Fix exit codes

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -1236,11 +1236,11 @@ mesg "${PURP}keychain ${OFF}${CYANN}${version}${OFF} ~ ${GREEN}http://www.funtoo
 if $clearopt; then
 	trap '' 2	# disallow ^C until we've had a chance to --clear
 	trap 'droplock; exit 1' 1 15	# drop the lock on signal
-	trap 'droplock; exit 0' 0		# drop the lock on exit
+	trap 'droplock;' 0		# drop the lock on exit
 else
 	# Don't use signal names because they don't work on Cygwin.
 	trap 'droplock; exit 1' 1 2 15	# drop the lock on signal
-	trap 'droplock; exit 0' 0		# drop the lock on exit
+	trap 'droplock;' 0		# drop the lock on exit
 fi
 
 setagents						# verify/set $agentsopt


### PR DESCRIPTION
Failed keychain executions always return success exit code. The problem
is that although keychain detects the failures and issues 'exit 1', in the
actions of the 'trap' builtin used to cleanup some lock files upon exit,
keychain masks the previous exit code by performing another 'exit 0'.

To fix that, remove 'exit 0' from the trap actions to preserve the
previous exit code of an internal exit invocation.