### PR TITLE
Fix keychain on (t)csh.

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -995,7 +995,7 @@ elif [ "$myaction" = ssh_rm ]; then
 else
 	# This will start gpg-agent as an ssh-agent if such functionality is enabled (default)
 	startagent_ssh || warn "Unable to start an ssh-agent (error code: $?)"
-	[ -n "$pidfile_out" ] && write_pidfile && eval "$pidfile_out" > /dev/null
+	[ -n "$pidfile_out" ] && write_pidfile && eval "$(catpidf_shell sh)" > /dev/null
 	if ! $gpg_started && wantagent gpg; then
 		# If we also want gpg, and it hasn't been started yet, start it also. We don't need to
 		# look for pidfile output, as this would have been output from the startagent_ssh->startagent_gpg


### PR DESCRIPTION
I'm not 100% sure of the fix because I'm not 100% sure of the intent. I feel like it's correct though, it's how one is supposed to bring the agent env variables in the current shell in all the rest of the code it seems.

Fixes #185